### PR TITLE
Fix such that resolveFun will not be given an undefined value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Deno environment
-        uses: denolib/setup-deno@v2.2.0
+        uses: denolib/setup-deno@v2.3.0
         with:
           deno-version: v1.4.6
 

--- a/src/resolvable.ts
+++ b/src/resolvable.ts
@@ -6,7 +6,7 @@ export interface Resolvable<T> {
 export interface ResolvablePromise<T> extends PromiseLike<T>, Resolvable<T> {}
 
 export function createResolvable<T>(): ResolvablePromise<T> {
-  let resolveFun: (value?: T | PromiseLike<T> | Promise<T>) => void;
+  let resolveFun: (value: T | PromiseLike<T> | Promise<T>) => void;
   let rejectFun: (reason?: any) => void;
 
   const promise = new Promise<T>((resolve, reject): void => {


### PR DESCRIPTION
I'll preface this with "I'm no typescript expert" - I was seeing an error in previously functioning code, after upgrading to 0.14.0 - looking at master, tests were reproducing the issue, as it was compile time.

Applying the fix below eliminates the compile time error, as resolveFun is no longer able to be passed an undefined value.

version upgrade in ci yaml fixes deprecation error from GitHub about use of insecure api. 