### PR TITLE
feature: Added support for TLS connection when flag present.

### DIFF
--- a/src/amqp_connect.ts
+++ b/src/amqp_connect.ts
@@ -21,9 +21,14 @@ export async function connect(
     loglevel,
     vhost,
     frameMax,
+    secure,
   } = parseOptions(optionsOrUrl);
 
-  const conn = await Deno.connect({ port, hostname });
+  const connect = secure
+    ? Deno.connectTls.bind(Deno, { port, hostname, certFile: typeof secure === "string" ? secure : undefined })
+    : Deno.connect.bind(Deno, { port, hostname });
+
+  const conn = await connect();
   const socket = new AmqpSocket(conn);
 
   const connection = new AmqpConnection(socket, {

--- a/src/amqp_connect.ts
+++ b/src/amqp_connect.ts
@@ -25,7 +25,11 @@ export async function connect(
   } = parseOptions(optionsOrUrl);
 
   const connect = secure
-    ? Deno.connectTls.bind(Deno, { port, hostname, certFile: typeof secure === "string" ? secure : undefined })
+    ? Deno.connectTls.bind(Deno, {
+        port,
+        hostname,
+        certFile: typeof secure === "string" ? secure : undefined,
+    })
     : Deno.connect.bind(Deno, { port, hostname });
 
   const conn = await connect();

--- a/src/amqp_connect_options.ts
+++ b/src/amqp_connect_options.ts
@@ -6,6 +6,11 @@ import { AmqpSocket } from "./amqp_socket.ts";
  */
 export interface AmqpConnectOptions {
   /**
+   * Whether to use a secure connection using a certificate (optional).
+   */
+  secure?: true | string;
+
+  /**
    * Hostname or literal IP-address to the AMQP broker. Defaults to 'localhost'.
    */
   hostname?: string;
@@ -40,7 +45,7 @@ export interface AmqpConnectOptions {
 
   /**
    * Sets the maximum frame size in number of bytes.
-   * 
+   *
    * This is negotiated with the broker during the connection handshake.
    */
   frameMax?: number;
@@ -62,15 +67,17 @@ export interface AmqpConnectParameters {
   vhost: string;
   heartbeatInterval?: number;
   frameMax?: number;
+  secure?: true | string;
   loglevel: "debug" | "none";
 }
 
 function parseUrl(value: string): AmqpConnectOptions {
-  if (!value.startsWith("amqp:")) {
+  const protocol = !value.match(/^amqps?:/);
+  if (!protocol) {
     throw new Error("Unsupported protocol");
   }
 
-  const url = new URL(value.replace("amqp:", "http:"));
+  const url = new URL(value.replace(/^amqp/, "http"));
 
   const heartbeatParam = url.searchParams.get("heartbeat");
   const heartbeat = heartbeatParam ? parseInt(heartbeatParam) : undefined;
@@ -107,6 +114,7 @@ export function parseOptions(
     loglevel = "none",
     vhost = "/",
     frameMax,
+    secure,
   } = typeof optionsOrString === "string"
     ? parseUrl(optionsOrString)
     : optionsOrString;
@@ -120,5 +128,6 @@ export function parseOptions(
     loglevel,
     vhost,
     frameMax,
+    secure,
   };
 }


### PR DESCRIPTION
I'm using AWS's MQ with RabbitMQ, but the endpoint it creates uses a secure connection which cannot be established using `Deno.connect()`; I added a flag that can be either `true` to just use `Deno.connectTls()` instead, or a `string` which would populate the `certFile` prop on Deno.connect's call. 

I tested it with my endpoint and it works, but since I'm just starting to evaluate if we're going to actually use RabbitMQ, I'll be just using my fork for the time being, but I didn't want to let pass the opportunity to contribute back.

If someone has the time to further test this, it would be great to have it merged so I would use the upstream version instead of my fork.

Thanks for the great work btw, cheers!


