### PR TITLE
Fix virtual host handling in URI parsing

### DIFF
--- a/src/amqp_connect_options.ts
+++ b/src/amqp_connect_options.ts
@@ -67,7 +67,7 @@ function parseUrl(value: string): AmqpConnectOptions {
     throw new Error("Unsupported protocol");
   }
 
-  const url = new URL(value.replace("amqp:", "http:"));
+  const url = new URL(value);
 
   const heartbeatParam = url.searchParams.get("heartbeat");
   const heartbeat = heartbeatParam ? parseInt(heartbeatParam) : undefined;

--- a/src/amqp_connect_options.ts
+++ b/src/amqp_connect_options.ts
@@ -86,7 +86,9 @@ function parseUrl(value: string): AmqpConnectOptions {
     port: parseInt(url.port || "5672"),
     username: url.username || "guest",
     password: url.password || "guest",
-    vhost: url.pathname,
+    vhost: url.pathname.length > 0
+      ? decodeURIComponent(url.pathname.substring(1))
+      : "/",
     heartbeatInterval: heartbeat,
     frameMax: frameMax,
   };

--- a/src/amqp_connect_options_test.ts
+++ b/src/amqp_connect_options_test.ts
@@ -79,14 +79,24 @@ Deno.test(...testUrl("amqp://user:pass@somehost.com:123", {
   password: "pass",
 }));
 
+Deno.test(...testUrl("amqp://localhost/%2f", {
+  ...defaultParams,
+  vhost: "/",
+}));
+
+Deno.test(...testUrl("amqp://localhost/%2fsomevhostwithslash", {
+  ...defaultParams,
+  vhost: "/somevhostwithslash",
+}));
+
 Deno.test(...testUrl("amqp://localhost/somevhost", {
   ...defaultParams,
-  vhost: "/somevhost",
+  vhost: "somevhost",
 }));
 
 Deno.test(...testUrl("amqp://localhost:123/somevhost", {
   ...defaultParams,
-  vhost: "/somevhost",
+  vhost: "somevhost",
   port: 123,
 }));
 


### PR DESCRIPTION
~~This fix breaks API a little bit by not setting vhost to `/` by default. Let me know if this is reasonable.~~

~~I tried implementing it in a way so that default value from function calls and uris without paths are still set to `/`, but I think `amqp://127.0.0.1` yielding vhost `/` and `amqp://127.0.0.1/` yielding empty vhost might be confusing and error prone.~~

Closes #30