### PR TITLE
Fix missing deno version on deploy

### DIFF
--- a/src/amqp_connection.ts
+++ b/src/amqp_connection.ts
@@ -41,7 +41,7 @@ function credentials(username: string, password: string) {
 
 const clientProperties = Object.freeze({
   product: "deno-amqp",
-  platform: `Deno ${Deno.version.deno} https://deno.land`,
+  platform: `Deno ${Deno.version?.deno} https://deno.land`,
   version: "0",
   information: "https://deno.land/x/amqp/",
 });


### PR DESCRIPTION
Using latests version of deno, amqp fail at runtime because Deno.version is undefined.

This is the detail of the error that I get using that library on supabase edge function based on deno.

TypeError: Cannot read properties of undefined (reading 'deno')
    at https://deno.land/x/amqp@v0.21.0/src/amqp_connection.ts:12:36