### PR TITLE
add test case for for verifying unexpected frames when sending chunks

### DIFF
--- a/deps_dev.ts
+++ b/deps_dev.ts
@@ -6,3 +6,4 @@ export {
   assertRejects,
   assertThrows,
 } from "https://deno.land/std@0.165.0/testing/asserts.ts";
+export { crypto } from "https://deno.land/std@0.165.0/crypto/mod.ts";

--- a/module_test/frame_error_test.ts
+++ b/module_test/frame_error_test.ts
@@ -1,0 +1,31 @@
+import { connect } from "../src/amqp_connect.ts";
+import { crypto } from "../deps_dev.ts";
+
+Deno.test(
+  "should not crash when sending large content frames concurrently",
+  async () => {
+    const conn = await connect({
+      heartbeatInterval: 0,
+      hostname: "127.0.0.1",
+      frameMax: 4096,
+    });
+
+    const message = new TextEncoder().encode("a".repeat(100000));
+
+    try {
+      const channel1 = await conn.openChannel();
+      const routingKey = `tmp_${crypto.randomUUID()}`;
+
+      for (const _ of Array.from({ length: 10 })) {
+        await Promise.all(
+          Array.from({ length: 100 }).map(() =>
+            channel1.publish({ routingKey }, {}, message)
+          ),
+        );
+      }
+    } finally {
+      await conn.close();
+      await conn.closed();
+    }
+  },
+);


### PR DESCRIPTION
Adding a test case to try and verify the race condition case in #38 .

I was not able to trigger a failure with the current version, but I could trigger it by modifying https://github.com/lenkan/deno-amqp/blob/master/src/amqp_channel.ts#L323 to await each frame first.

Note: I am not saying that #38 does not fix the problem. But first I want to add a test case that confirms the issue with the current version of the code. I want to move the guard into amqp_channel and get rid of amqp_multiplexer.ts altogether.